### PR TITLE
Fixing mainBuildJsTasks missing prefix.

### DIFF
--- a/lib/options.js
+++ b/lib/options.js
@@ -19,7 +19,6 @@ function normalizeOptions(options) {
 	options.formatGlobs = options.formatGlobs || codeGlobs;
 	options.globalName = options.globalName || 'metal';
 	options.lintGlobs = options.lintGlobs || codeGlobs;
-	options.mainBuildJsTasks = options.mainBuildJsTasks || ['build:globals'];
 	options.moduleName = options.moduleName || 'metal';
 	options.scssIncludePaths = options.scssIncludePaths || ['bower_components'];
 	options.scssSrc = options.scssSrc || 'src/**/*.scss';
@@ -29,6 +28,7 @@ function normalizeOptions(options) {
 	options.soyShouldGenerateJsComponent = !!options.soyShouldGenerateJsComponent;
 	options.soySrc = options.soySrc || 'src/**/*.soy';
 	options.taskPrefix = options.taskPrefix || '';
+	options.mainBuildJsTasks = options.mainBuildJsTasks || [options.taskPrefix + 'build:globals'];
 
 	return options;
 }


### PR DESCRIPTION
Another edge case: An error is happening if I use a prefix for my metal-related tasks.
