### PR TITLE
Fixes Microsoft Edge version for saucelabs

### DIFF
--- a/lib/options.js
+++ b/lib/options.js
@@ -70,11 +70,11 @@ function normalizeOptions(options) {
 			platform: 'Windows 8.1',
 			version: '11'
 		},
-		sl_edge_20: {
+		sl_edge_13: {
 			base: 'SauceLabs',
 			browserName: 'microsoftedge',
 			platform: 'Windows 10',
-			version: '20'
+			version: '13'
 		},
 		sl_iphone: {
 			base: 'SauceLabs',


### PR DESCRIPTION
According to https://wiki.saucelabs.com/display/DOCS/Platform+Configurator#/, there is no Edge version 20.

According to some of these links, the more used Edge version is 13

http://caniuse.com/usage-table
https://www.netmarketshare.com/browser-market-share.aspx?qprid=2&qpcustomd=0
