### PR TITLE
Adds more custom Saucelabs options

### DIFF
--- a/lib/options.js
+++ b/lib/options.js
@@ -42,6 +42,16 @@ function normalizeOptions(options) {
 	options.uglifySrc = options.uglifySrc || 'build/**/*.js';
 	options.moduleName = options.moduleName || 'metal';
 	options.noSoy = options.noSoy || false;
+	options.sauceLabs = Object.assign({
+		connectOptions: {
+			port: 5757,
+			logfile: 'sauce_connect.log'
+		},
+		startConnect: true,
+		recordScreenshots: false,
+		recordVideo: false,
+		testName: options.moduleName + ' tests'
+	}, options.sauceLabs);
 	options.scssIncludePaths = options.scssIncludePaths || ['node_modules'];
 	options.scssSrc = options.scssSrc || 'src/**/*.scss';
 	options.soyDest = options.soyDest || 'src';

--- a/lib/tasks/test.js
+++ b/lib/tasks/test.js
@@ -94,15 +94,7 @@ module.exports = function(options) {
 
 			reporters: ['dots', 'saucelabs'],
 
-			sauceLabs: {
-				testName: 'MetalJS tests',
-				recordScreenshots: false,
-				startConnect: true,
-				connectOptions: {
-					port: 5757,
-					logfile: 'sauce_connect.log'
-				}
-			},
+			sauceLabs: options.sauceLabs,
 
 			singleRun: true
 		};

--- a/test/lib/tasks/test.js
+++ b/test/lib/tasks/test.js
@@ -272,6 +272,61 @@ describe('Test Tasks', function() {
 		});
 	});
 
+	it('should not let Saucelabs record screenshots by default', function(done) {
+		registerTestTasks({karma: karmaStub});
+
+		gulp.start('test:saucelabs', function() {
+			var config = karmaStub.Server.args[0][0];
+			assert.strictEqual(false, config.sauceLabs.recordScreenshots);
+			done();
+		});
+	});
+
+	it('should not let Saucelabs record video by defaul', function(done) {
+		registerTestTasks({karma: karmaStub});
+
+		gulp.start('test:saucelabs', function() {
+			var config = karmaStub.Server.args[0][0];
+			assert.strictEqual(false, config.sauceLabs.recordVideo);
+			done();
+		});
+	});
+
+	it('should not let Saucelabs start connection by default', function(done) {
+		registerTestTasks({karma: karmaStub});
+
+		gulp.start('test:saucelabs', function() {
+			var config = karmaStub.Server.args[0][0];
+			assert.strictEqual(false, config.sauceLabs.startConnect);
+			done();
+		});
+	});
+
+	it('should be able to overwrite saucelabs default options', function(done) {
+		registerTestTasks({
+			karma: karmaStub,
+			sauceLabs: {
+				recordScreenshots: true,
+				recordVideo: true,
+				startConnect: false,
+				testName: 'My custom teste name'
+			}
+		});
+
+		gulp.start('test:saucelabs', function() {
+			var config = karmaStub.Server.args[0][0];
+			assert.strictEqual(true, config.sauceLabs.recordScreenshots);
+			assert.strictEqual(true, config.sauceLabs.recordVideo);
+			assert.strictEqual(false, config.sauceLabs.startConnect);
+			assert.strictEqual('My custom teste name', config.sauceLabs.testName);
+
+			// Unchanged options remains the same
+			assert.strictEqual('sauce_connect.log', config.sauceLabs.connectOptions.logfile);
+			assert.strictEqual(5757, config.sauceLabs.connectOptions.port);
+			done();
+		});
+	});
+
 	it('should pass singleRun as false when test:watch is run', function(done) {
 		registerTestTasks({karma: karmaStub});
 


### PR DESCRIPTION
The idea is providing the way to use Saucelabs more efficiently. For example, `recordVideo` helped me to find out why Metal.JS tests were failing in Android devices. I had to use my `gulp-metal` fork to edit this option in order to use this feature. It'd be quite easier if I could only pass down this option through `registerTasks()`.

Probably it would be a good chance to discuss the possibility to do the same for all Karma options. What do you guys think about it?