### PR TITLE
Updates metal-karma-config

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "karma-safari-launcher": "^0.1.1",
     "karma-sauce-launcher": "^0.3.0",
     "merge": "^1.2.0",
-    "metal-karma-config": "^2.0.2",
+    "metal-karma-config": "^2.2.0",
     "metal-tools-build-amd": "^3.0.0",
     "metal-tools-build-globals": "^2.0.0",
     "metal-tools-build-jquery": "^2.0.0",


### PR DESCRIPTION
@ipeychev, I've noticed that `gulp-metal` wasn't loading the latest version of `metal-karma-config`. For this reason, `sinon` wasn't being downloaded.

