### PR TITLE
Set Prettier setting trailingComma to es5 so that mocha tests are not…

### DIFF
--- a/lib/tasks/index.js
+++ b/lib/tasks/index.js
@@ -39,7 +39,7 @@ module.exports = function(options) {
 				bracketSpacing: false,
 				singleQuote: true,
 				tabWidth: 4,
-				trailingComma: 'all',
+				trailingComma: 'es5',
 				useTabs: true
 			})
 		);


### PR DESCRIPTION
Currently `trailingComma` is set to `all`, which can potentially break code that isn't transpiled (like test files for example).

Here is a mocha test formatted with `all`.

```javascript
it('this is a long test description that causes the arguments to break to the next line', function(
	done,
) {
	done();
});
```

This test won't run due to the trailing comma. Here is the same code formatted with `es5`.

```javascript
it('this is a long test description that causes the arguments to break to the next line', function(
	done
) {
	done();
});
```

Obviously we could not run the formatter against test files, but I think we should.
