### PR TITLE
[FEEDBACK NEEDED] Adds jest test:snapshot task

### DIFF
--- a/lib/tasks/test.js
+++ b/lib/tasks/test.js
@@ -12,6 +12,9 @@ var mocha = require('gulp-mocha');
 var normalizeOptions = require('../options');
 var openFile = require('open');
 var path = require('path');
+var through = require('through2');
+var jest = require('jest-cli');
+
 
 module.exports = function(options) {
 	options = normalizeOptions(options);
@@ -20,8 +23,24 @@ module.exports = function(options) {
 
 	var runSequence = require('run-sequence').use(gulp);
 
+	var testSnapshot = function(file, encoding, cb) {
+		options = Object.assign({}, options, {
+			config: Object.assign({
+				rootDir: file ? file.path : undefined
+			}, options.config)
+		});
+
+		jest.runCLI(options, [options.config.rootDir], (result) => {
+			if(result.numFailedTests || result.numFailedTestSuites) {
+				cb(new gutil.PluginError('gulp-jest', { message: 'Tests Failed' }));
+			} else {
+				cb();
+			}
+		});
+	};
+
 	gulp.task(taskPrefix + 'test', function(done) {
-		runSequence(taskPrefix + 'test:unit', function() {
+		runSequence(/*[taskPrefix + 'test:unit', */taskPrefix + 'test:snapshot'/*]*/, function() {
 			done();
 		});
 	});
@@ -36,6 +55,15 @@ module.exports = function(options) {
 
 			done(err);
 		});
+	});
+
+	gulp.task(taskPrefix + 'test:snapshot', options.testDepTasks, function() {
+		var gulpOpts = {
+			base: process.cwd()
+		};
+
+		return gulp.src('src/__tests__/**/*.js', gulpOpts)
+	    .pipe(through.obj(testSnapshot));
 	});
 
 	gulp.task(taskPrefix + 'test:coverage', options.testDepTasks, function(done) {

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
   },
   "devDependencies": {
     "babel-deps": "^2.0.0",
+    "jest-cli": "^20.0.4",
     "metal": "^1.0.0-rc",
     "mocha": "^2.2.5",
     "mockery": "^1.4.0",


### PR DESCRIPTION
Hey guys, I'm just opening this to start a discussion about adding some kind of `jest` pipeline to our test infrastructure. This should be specially beneficial for component/snapshot testing. I've pushed an example commit to https://github.com/metal/metal-clay-components/commit/ea4db2e477f807ed8f2fe97a0d676b10fa09a676 as well after locally linking this version of `gulp-metal`.

What I'd like to discuss is:
- Does it make sense to integrate jest into our current karma+mocha setup?
- If so, what would be the best way?
- It's [not trivial to use jest for real browser testing](https://github.com/facebook/jest/issues/848), so just porting all the tests there is out of the question... [or is it](https://github.com/facebook/jest/issues/139#issuecomment-229277654)?

What do you guys think?

/cc @eduardolundgren, @Robert-Frampton, @brunobasto, @julien, @izaera, @mthadley, @bryceosterhaus, @ethib137 